### PR TITLE
Updating color of costants

### DIFF
--- a/themes/loki-theme-kang-edition.json
+++ b/themes/loki-theme-kang-edition.json
@@ -541,7 +541,7 @@
         "variable.other.constant"
       ],
       "settings": {
-        "foreground": "#93e6f9"
+        "foreground": "#F8F8F2"
       }
     },
     {


### PR DESCRIPTION
Old color: `#93E6F9`
![Captura de tela de 2021-09-11 22-17-19](https://user-images.githubusercontent.com/50425715/132967741-bb088746-a697-466e-b9f8-cf5e4b08d015.png)

New color: `#F8F8F2`
![expected-color](https://user-images.githubusercontent.com/50425715/132967745-7a075bb2-3480-4b53-8935-a79cc2b2a4ca.png)

resolves #1 