### PR TITLE
Updating color from classic theme edition constants

### DIFF
--- a/themes/loki-theme-color-theme.json
+++ b/themes/loki-theme-color-theme.json
@@ -353,7 +353,7 @@
         "variable.other.constant"
       ],
       "settings": {
-        "foreground": "#FEC675"
+        "foreground": "#F8F8F2"
       }
     },
     {


### PR DESCRIPTION
## What has changed
Updated the color of the name of constants in the **Classic Edition** of the theme

Current color: `#FEC675`
![current-color-classic-theme](https://user-images.githubusercontent.com/50425715/132967688-ad536853-1485-47e7-9274-c435fe3dac22.png)

Expected color: `#F8F8F2`
![expected-color-classic-theme](https://user-images.githubusercontent.com/50425715/132967691-af6d5e81-83aa-4827-b1b0-f4c9c5c1c656.png)

resolve #1 